### PR TITLE
CDC support v1: add table property to identify change kind column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,20 @@
 <!--            <scope>test</scope>-->
         </dependency>
 
+        <dependency>
+            <groupId>org.pegdown</groupId>
+            <artifactId>pegdown</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>0.35.10</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>junit</groupId>
@@ -314,6 +328,7 @@
                 <configuration>
                     <testFailureIgnore>true</testFailureIgnore>
                     <runpath>target/scala-2.12/classes,target/scala-2.12/test-classes</runpath>
+                    <htmlreporters>${project.build.directory}/html/scalatest</htmlreporters>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/scala/com/dmetasoul/lakesoul/tables/LakeSoulTable.scala
+++ b/src/main/scala/com/dmetasoul/lakesoul/tables/LakeSoulTable.scala
@@ -489,6 +489,11 @@ object LakeSoulTable {
       this
     }
 
+    def tableProperty(kv: (String, String)): TableCreator = {
+      options.put(kv._1, kv._2)
+      this
+    }
+
     def create(): Unit = {
       val writer = writeData.write.format(LakeSoulSourceUtils.NAME).mode("overwrite")
       options.foreach(f => writer.option(f._1, f._2))

--- a/src/main/scala/org/apache/spark/sql/lakesoul/LakeSoulUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/LakeSoulUtils.scala
@@ -246,6 +246,16 @@ object LakeSoulTableV2ScanRelation {
   }
 }
 
+object LakeSoulTableProperties {
+
+  val lakeSoulCDCChangePropKey = "lakesoul_cdc_change_column"
+
+  val extraTblProps = Set(lakeSoulCDCChangePropKey)
+
+  def isLakeSoulTableProperty(name: String): Boolean = {
+    extraTblProps.contains(name)
+  }
+}
 
 class MergeOpLong extends MergeOperator[Long] {
   override def mergeData(input: Seq[Long]): Long = {

--- a/src/main/scala/org/apache/spark/sql/lakesoul/TransactionCommit.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/TransactionCommit.scala
@@ -242,7 +242,6 @@ trait Transaction extends TransactionalWrite with Logging {
     files
   }
 
-
   def commit(addFiles: Seq[DataFileInfo],
              expireFiles: Seq[DataFileInfo],
              newTableInfo: TableInfo): Unit = {

--- a/src/main/scala/org/apache/spark/sql/lakesoul/commands/CreateTableCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/commands/CreateTableCommand.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.lakesoul.exception.LakeSoulErrors
 import org.apache.spark.sql.lakesoul.schema.SchemaUtils
 import org.apache.spark.sql.lakesoul.utils.{DataFileInfo, TableInfo}
-import org.apache.spark.sql.lakesoul.{SnapshotManagement, LakeSoulOptions, TransactionCommit}
+import org.apache.spark.sql.lakesoul.{LakeSoulOptions, LakeSoulTableProperties, SnapshotManagement, TransactionCommit}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -149,7 +149,7 @@ case class CreateTableCommand(table: CatalogTable,
         snapshotManagement,
         newMode,
         options,
-        configuration = Map.empty, //table.properties,
+        configuration = table.properties.filterKeys(LakeSoulTableProperties.isLakeSoulTableProperty), //table.properties,
         data).write(tc, sparkSession)
 
       tc.commit(newFiles, deletedFiles)

--- a/src/main/scala/org/apache/spark/sql/lakesoul/commands/WriteIntoTable.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/commands/WriteIntoTable.scala
@@ -69,7 +69,6 @@ case class WriteIntoTable(snapshotManagement: SnapshotManagement,
   override protected val materialSQLText: String = options.materialSQLText
   override protected val materialAutoUpdate: Boolean = options.materialAutoUpdate
 
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     snapshotManagement.withNewTransaction { tc =>
       val (addFiles, expireFiles) = write(tc, sparkSession)

--- a/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulDataSource.scala
@@ -99,7 +99,7 @@ class LakeSoulDataSource
       snapshot_manage,
       mode = mode,
       new LakeSoulOptions(parameters, sqlContext.sparkSession.sessionState.conf),
-      Map.empty,
+      parameters.filterKeys(LakeSoulTableProperties.isLakeSoulTableProperty),
       data).run(sqlContext.sparkSession)
 
     snapshot_manage.createRelation()

--- a/src/main/scala/org/apache/spark/sql/lakesoul/utils/MetaData.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/utils/MetaData.scala
@@ -20,6 +20,7 @@ import com.dmetasoul.lakesoul.meta.{CommitState, CommitType, MetaUtils}
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.execution.datasources.BucketingUtils
+import org.apache.spark.sql.lakesoul.LakeSoulTableProperties
 import org.apache.spark.sql.lakesoul.material_view.QueryInfo
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -113,9 +114,7 @@ case class TableInfo(table_name: String,
   }
 
   lazy val format: Format = Format()
-
 }
-
 
 //single file info
 case class DataFileInfo(file_path: String,


### PR DESCRIPTION
# CDC support v1
This patch adds a table property 'lakesoul_cdc_change_column' to identify a change kind column in one LakeSoul table.

# Design
This column should be of type string and could only contain values in one of ('update', 'delete', 'insert'). This allows LakeSoul table to represent a continuous change status according to upstream changing data. And LakeSoul is able to accept different kinds of CDC sources including Debezium, Canal and Flink CDC.

# Implementation
1. Allow `create table` and `alter table` to set TBLPROPERTIES with key 'lakesoul_cdc_change_column'
2. Fix the case when using DataFrame API or TableCreator API to create table but table options were incorrectly ignored

# Testing
1. Add test cases including table creation with property via SQL, DataFrame and TableCreator API
2. Add test case for alter table DDL