### PR TITLE
support merge into sql when can be converted to upsert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
             <!--<scope>provided</scope>-->
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- scala deps -->
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
+++ b/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
@@ -95,9 +95,15 @@ class LakeSoulSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectPostHocResolutionRule { session =>
       PreprocessTableUpdate(session.sessionState.conf)
     }
+
+    extensions.injectPostHocResolutionRule { session =>
+      PreprocessTableMergeInto(session.sessionState.conf)
+    }
+
     extensions.injectPostHocResolutionRule { session =>
       PreprocessTableUpsert(session.sessionState.conf)
     }
+
     extensions.injectPostHocResolutionRule { session =>
       PreprocessTableDelete(session.sessionState.conf)
     }

--- a/src/main/scala/org/apache/spark/sql/lakesoul/TransactionCommit.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/TransactionCommit.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
 import org.apache.spark.sql.lakesoul.utils._
 
 import java.util.ConcurrentModificationException
-import scala.collection.mutable.{ArrayBuffer, HashSet}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 class TransactionCommit(override val snapshotManagement: SnapshotManagement) extends Transaction {
 
@@ -39,7 +40,7 @@ object TransactionCommit {
   private val active = new ThreadLocal[TransactionCommit]
 
   /** Get the active transaction */
-  def getActive(): Option[TransactionCommit] = Option(active.get())
+  def getActive: Option[TransactionCommit] = Option(active.get())
 
   /**
     * Sets a transaction as the active transaction.
@@ -62,8 +63,6 @@ object TransactionCommit {
   private[lakesoul] def clearActive(): Unit = {
     active.set(null)
   }
-
-
 }
 
 class PartMergeTransactionCommit(override val snapshotManagement: SnapshotManagement) extends Transaction {
@@ -74,7 +73,7 @@ object PartMergeTransactionCommit {
   private val active = new ThreadLocal[PartMergeTransactionCommit]
 
   /** Get the active transaction */
-  def getActive(): Option[PartMergeTransactionCommit] = Option(active.get())
+  def getActive: Option[PartMergeTransactionCommit] = Option(active.get())
 
   /**
     * Sets a transaction as the active transaction.
@@ -97,10 +96,7 @@ object PartMergeTransactionCommit {
   private[lakesoul] def clearActive(): Unit = {
     active.set(null)
   }
-
-
 }
-
 
 trait Transaction extends TransactionalWrite with Logging {
   val snapshotManagement: SnapshotManagement
@@ -152,14 +148,13 @@ trait Transaction extends TransactionalWrite with Logging {
   protected val readPredicates = new ArrayBuffer[Expression]
 
   /** Tracks specific files that have been seen by this transaction. */
-  protected val readFiles = new HashSet[DataFileInfo]
+  protected val readFiles = new mutable.HashSet[DataFileInfo]
 
   /** Tracks if this transaction has already committed. */
   protected var committed = false
 
   /** Stores the updated TableInfo (if any) that will result from this tc. */
   protected var newTableInfo: Option[TableInfo] = None
-
 
   /** For new tables, fetch global configs as TableInfo. */
   private val snapshotTableInfo: TableInfo = if (snapshot.isFirstCommit) {
@@ -236,7 +231,7 @@ trait Transaction extends TransactionalWrite with Logging {
       partitionInfo.range_id,
       partitionInfo.range_value,
       partitionInfo.read_version,
-      true)
+      allow_filtering = true)
 
     readFiles ++= files
     files
@@ -384,10 +379,7 @@ trait Transaction extends TransactionalWrite with Logging {
       }
 
       committed = true
-
     }
     snapshotManagement.updateSnapshot()
   }
-
-
 }

--- a/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulCatalog.scala
@@ -243,7 +243,7 @@ class LakeSoulCatalog(val spark: SparkSession) extends DelegatingCatalogExtensio
                                      query: Option[LogicalPlan]): CatalogTable = {
 
     if (tableDesc.bucketSpec.isDefined) {
-      throw LakeSoulErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+      throw LakeSoulErrors.operationNotSupportedException("Bucketing", Some(tableDesc.identifier))
     }
 
     val ori_schema = query.map { plan =>

--- a/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulScanBuilder.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulScanBuilder.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.lakesoul.catalog
 
 import com.dmetasoul.lakesoul.meta.{MaterialView, MetaCommit}
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions
@@ -46,14 +47,14 @@ case class LakeSoulScanBuilder(sparkSession: SparkSession,
                                options: CaseInsensitiveStringMap,
                                tableInfo: TableInfo)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) with SupportsPushDownFilters with Logging {
-  lazy val hadoopConf = {
+  lazy val hadoopConf: Configuration = {
     val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
       .filter(!_._1.startsWith(LakeSoulUtils.MERGE_OP_COL))
     // Hadoop Configurations are case sensitive.
     sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
   }
 
-  lazy val pushedParquetFilters = {
+  lazy val pushedParquetFilters: Array[Filter] = {
     val sqlConf = sparkSession.sessionState.conf
     val pushDownDate = sqlConf.parquetFilterPushDownDate
     val pushDownTimestamp = sqlConf.parquetFilterPushDownTimestamp

--- a/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulTableV2.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/catalog/LakeSoulTableV2.scala
@@ -97,7 +97,7 @@ case class LakeSoulTableV2(spark: SparkSession,
   }
 
   override def capabilities(): java.util.Set[TableCapability] = Set(
-    ACCEPT_ANY_SCHEMA, BATCH_READ, //BATCH_WRITE, OVERWRITE_DYNAMIC,
+    /* ACCEPT_ANY_SCHEMA, */ BATCH_READ, //BATCH_WRITE, OVERWRITE_DYNAMIC,
     V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE
   ).asJava
 

--- a/src/main/scala/org/apache/spark/sql/lakesoul/exception/LakeSoulErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/exception/LakeSoulErrors.scala
@@ -386,10 +386,14 @@ object LakeSoulErrors {
       s"Operation not allowed: `$operation` is not supported for LakeSoul tables")
   }
 
-  def operationNotSupportedException(operation: String, tableIdentifier: TableIdentifier): Throwable = {
-    new AnalysisException(
-      s"Operation not allowed: `$operation` is not supported " +
-        s"for lakesoul tables: $tableIdentifier")
+  def operationNotSupportedException(operation: String, tableIdentifier: Option[TableIdentifier]): Throwable = {
+    tableIdentifier match {
+      case None => operationNotSupportedException(operation)
+      case Some(identifier) =>
+        new AnalysisException(
+          s"Operation not allowed: `$operation` is not supported " +
+            s"for lakesoul tables: $tableIdentifier")
+    }
   }
 
   def alterTableChangeColumnException(oldColumns: String, newColumns: String): Throwable = {

--- a/src/main/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulAnalysis.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulAnalysis.scala
@@ -95,7 +95,6 @@ case class LakeSoulAnalysis(session: SparkSession, sqlConf: SQLConf)
         // Not a well-defined LakeSoul table
         throw LakeSoulErrors.notALakeSoulSourceException("UPDATE", Some(u))
       }
-
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulUnsupportedOperationsCheck.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulUnsupportedOperationsCheck.scala
@@ -34,7 +34,7 @@ case class LakeSoulUnsupportedOperationsCheck(spark: SparkSession)
 
   private def fail(operation: String, tableIdent: TableIdentifier): Unit = {
     if (LakeSoulUtils.isLakeSoulTable(spark, tableIdent)) {
-      throw LakeSoulErrors.operationNotSupportedException(operation, tableIdent)
+      throw LakeSoulErrors.operationNotSupportedException(operation, Some(tableIdent))
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/lakesoul/rules/PreprocessTableMergeInto.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/rules/PreprocessTableMergeInto.scala
@@ -1,0 +1,76 @@
+package org.apache.spark.sql.lakesoul.rules
+
+import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, InsertAction, LakeSoulUpsert, LogicalPlan, MergeAction, MergeIntoTable, UpdateAction}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.lakesoul.LakeSoulTableRelationV2
+import org.apache.spark.sql.lakesoul.catalog.LakeSoulTableV2
+import org.apache.spark.sql.lakesoul.exception.LakeSoulErrors
+
+case class PreprocessTableMergeInto(sqlConf: SQLConf) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case m@MergeIntoTable(targetTable, sourceTable, mergeCondition, matchedActions, notMatchedActions)
+      if m.resolved =>
+
+      EliminateSubqueryAliases(targetTable) match {
+        case LakeSoulTableRelationV2(tbl: LakeSoulTableV2) =>
+          if (lakeSoulTableHasHashPartition(tbl)
+            && isMergeConditionOnPrimaryKey(mergeCondition, tbl)
+            && matchedActionIsOneUpdateOnly(matchedActions)
+            && notMatchedActionIsOneInsertOnly(notMatchedActions))
+          {
+            logInfo(s"Merge into ${tbl.name()} is optimized to Upsert")
+            LakeSoulUpsert(targetTable, sourceTable, "")
+          } else {
+            throw LakeSoulErrors.operationNotSupportedException("Merge into with (not)matched conditions")
+          }
+      }
+  }
+
+  private def isMergeConditionOnPrimaryKey(mergeCondition: Expression, tbl: LakeSoulTableV2): Boolean = {
+    val hashColumnNameHit = scala.collection.mutable.Map(
+      tbl.snapshotManagement.snapshot.getTableInfo
+        .hash_partition_schema.fieldNames.map(k => k -> false): _*)
+    var notQualifiedCondition = false
+    mergeCondition foreachUp {
+      case EqualTo(left: AttributeReference, right: AttributeReference)
+        if left.name == right.name =>
+        if (hashColumnNameHit.contains(left.name)) hashColumnNameHit(left.name) = true
+        else notQualifiedCondition = true
+      case And(_, _) | AttributeReference(_, _, _, _) =>
+      case _ => notQualifiedCondition = true
+    }
+    !notQualifiedCondition && hashColumnNameHit.forall(_._2)
+  }
+
+  private def lakeSoulTableHasHashPartition(table: LakeSoulTableV2): Boolean = {
+    table.snapshotManagement.snapshot.getTableInfo.hash_column.nonEmpty
+  }
+
+  private def assignmentsIsAttributeOnly(assignments: Seq[Assignment]): Boolean = {
+    assignments.forall( a => a.key.isInstanceOf[AttributeReference]
+      && a.value.isInstanceOf[AttributeReference])
+  }
+
+  private def matchedActionIsOneUpdateOnly(matchedAction: Seq[MergeAction]): Boolean = {
+    matchedAction match {
+      case Seq(UpdateAction(condition, assignments))
+        if condition.isEmpty && assignmentsIsAttributeOnly(assignments) =>
+        true
+      case _ => false
+    }
+  }
+
+  private def notMatchedActionIsOneInsertOnly(notMatchedAction: Seq[MergeAction]): Boolean = {
+    notMatchedAction match {
+      case Seq(InsertAction(condition, assignments))
+        if condition.isEmpty && assignmentsIsAttributeOnly(assignments) =>
+        true
+      case _ => false
+    }
+  }
+
+}

--- a/src/test/scala/org/apache/spark/sql/lakesoul/DataFrameWriterV2Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/DataFrameWriterV2Suite.scala
@@ -100,7 +100,7 @@ trait DataFrameWriterV2Tests
       spark.table("source").withColumnRenamed("data", "d").writeTo("table_name").append()
     }
 
-    assert(exc.getMessage.contains("schema mismatch"))
+    assert(exc.getMessage.contains("Cannot write incompatible data to table"))
 
     checkAnswer(
       spark.table("table_name"),
@@ -166,7 +166,7 @@ trait DataFrameWriterV2Tests
         .writeTo("table_name").overwrite(lit(true))
     }
 
-    assert(exc.getMessage.contains("schema mismatch"))
+    assert(exc.getMessage.contains("Cannot write incompatible data to table"))
 
     checkAnswer(
       spark.table("table_name"),
@@ -231,7 +231,7 @@ trait DataFrameWriterV2Tests
         .writeTo("table_name").overwritePartitions()
     }
 
-    assert(e.getMessage.contains("Table default.table_name does not support dynamic overwrite"))
+    assert(e.getMessage.contains("Cannot write incompatible data to table"))
 
     checkAnswer(
       spark.table("table_name"),

--- a/src/test/scala/org/apache/spark/sql/lakesoul/TableCreationTests.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/TableCreationTests.scala
@@ -46,7 +46,7 @@ trait TableCreationTests
 
   val format = "lakesoul"
 
-  private def createTableByPath(path: File,
+  protected def createTableByPath(path: File,
                                 df: DataFrame,
                                 tableName: String,
                                 partitionedBy: Seq[String] = Nil): Unit = {
@@ -179,10 +179,19 @@ trait TableCreationTests
       withTempDir { dir =>
         val tbl = "lakesoul_test"
         withTable(tbl) {
-          createTableByPath(dir, Seq(1L -> "a").toDF("v1", "v2"), tbl, cols)
+          createTableByPath(dir,
+            createDF(
+              Seq(1L -> "a"),
+              Seq("v1", "v2"),
+              Seq("long", "string")
+            ),
+            tbl, cols)
 
-          Seq(2L -> "b").toDF("v1", "v2")
-            .write
+          createDF(
+            Seq(2L -> "b"),
+            Seq("v1", "v2"),
+            Seq("long", "string")
+          ).write
             .partitionBy(cols: _*)
             .mode(SaveMode.Append)
             .format(format)
@@ -257,8 +266,11 @@ trait TableCreationTests
   test("saveAsTable (append) + insert to a table created without a schema") {
     withTempDir { dir =>
       withTable("lakesoul_test") {
-        Seq(1L -> "a").toDF("v1", "v2")
-          .write
+        createDF(
+          Seq(1L -> "a"),
+          Seq("v1", "v2"),
+          Seq("long", "string")
+        ).write
           .mode(SaveMode.Append)
           .partitionBy("v2")
           .format(format)
@@ -266,15 +278,21 @@ trait TableCreationTests
           .saveAsTable("lakesoul_test")
 
         // Out of order
-        Seq("b" -> 2L).toDF("v2", "v1")
-          .write
+        createDF(
+          Seq("b" -> 2L),
+          Seq("v2", "v1"),
+          Seq("string", "long")
+        ).write
           .partitionBy("v2")
           .mode(SaveMode.Append)
           .format(format)
           .saveAsTable("lakesoul_test")
 
-        Seq(3L -> "c").toDF("v1", "v2")
-          .write
+        createDF(
+          Seq(3L -> "c"),
+          Seq("v1", "v2"),
+          Seq("long", "string")
+        ).write
           .format(format)
           .insertInto("lakesoul_test")
 
@@ -1474,5 +1492,4 @@ class TableCreationSuite
       }
     }
   }
-
 }

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
@@ -1,24 +1,65 @@
 package org.apache.spark.sql.lakesoul.commands
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.util.Utils
+import org.scalatest._
+import matchers.should.Matchers._
 
 class MergeIntoSQLSuite extends UpsertSuiteBase with LakeSQLCommandSoulTest {
 
   import testImplicits._
 
-  test("merge into table with hash partition -- supported case") {
+  private def initHashTable(): Unit = {
     initTable(
       Seq((20201101, 1, 1), (20201101, 2, 2), (20201101, 3, 3), (20201102, 4, 4))
         .toDF("range", "hash", "value"),
       "range",
       "hash")
-    Seq((20201102, 4, 5)).toDF("range", "hash", "value").createOrReplaceTempView("source_table")
-    sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
-      s" ON t.hash = s.hash" +
-      s" WHEN MATCHED THEN UPDATE SET *" +
-      s" WHEN NOT MATCHED THEN INSERT *")
-    checkAnswer(readLakeSoulTable(tempPath).selectExpr("range", "hash", "value"),
-      Row(20201101, 1, 1) :: Row(20201101, 2, 2) :: Row(20201101, 3, 3) :: Row(20201102, 4, 5) :: Nil)
+  }
+
+  private def withViewNamed(df: DataFrame, viewName: String)(f: => Unit): Unit = {
+    df.createOrReplaceTempView(viewName)
+    Utils.tryWithSafeFinally(f) {
+      spark.catalog.dropTempView(viewName)
+    }
+  }
+
+  test("merge into table with hash partition -- supported case") {
+    initHashTable()
+    withViewNamed(Seq((20201102, 4, 5)).toDF("range", "hash", "value"), "source_table") {
+      sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
+        s" ON t.hash = s.hash" +
+        s" WHEN MATCHED THEN UPDATE SET *" +
+        s" WHEN NOT MATCHED THEN INSERT *")
+      checkAnswer(readLakeSoulTable(tempPath).selectExpr("range", "hash", "value"),
+        Row(20201101, 1, 1) :: Row(20201101, 2, 2) :: Row(20201101, 3, 3) :: Row(20201102, 4, 5) :: Nil)
+    }
+  }
+
+  test("merge into table with hash partition -- invalid merge condition") {
+    initHashTable()
+    withViewNamed(Seq((20201102, 4, 5)).toDF("range", "hash", "value"), "source_table") {
+      val e = intercept[AnalysisException] {
+        sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
+          s" ON t.value = s.value" +
+          s" WHEN MATCHED THEN UPDATE SET *" +
+          s" WHEN NOT MATCHED THEN INSERT *")
+      }
+      e.getMessage() should (include("Convert merge into to upsert with merge condition") and include("is not supported"))
+    }
+  }
+
+  test("merge into table with hash partition -- invalid matched condition") {
+    initHashTable()
+    withViewNamed(Seq((20201102, 4, 5)).toDF("range", "hash", "value"), "source_table") {
+      val e = intercept[AnalysisException] {
+        sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
+          s" ON t.hash = s.hash" +
+          s" WHEN MATCHED THEN UPDATE SET *" +
+          s" WHEN NOT MATCHED THEN INSERT *")
+      }
+      e.getMessage() should (include("Convert merge into to upsert with merge condition") and include("is not supported"))
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.sql.lakesoul.commands
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+
+class MergeIntoSQLSuite extends UpsertSuiteBase with LakeSQLCommandSoulTest {
+
+  import testImplicits._
+
+  test("merge into table with hash partition -- supported case") {
+    initTable(
+      Seq((20201101, 1, 1), (20201101, 2, 2), (20201101, 3, 3), (20201102, 4, 4))
+        .toDF("range", "hash", "value"),
+      "range",
+      "hash")
+    Seq((20201102, 4, 5)).toDF("range", "hash", "value").createOrReplaceTempView("source_table")
+    sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
+      s" ON t.hash = s.hash" +
+      s" WHEN MATCHED THEN UPDATE SET *" +
+      s" WHEN NOT MATCHED THEN INSERT *")
+    checkAnswer(readLakeSoulTable(tempPath).selectExpr("range", "hash", "value"),
+      Row(20201101, 1, 1) :: Row(20201101, 2, 2) :: Row(20201101, 3, 3) :: Row(20201102, 4, 5) :: Nil)
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/MergeIntoSQLSuite.scala
@@ -56,10 +56,10 @@ class MergeIntoSQLSuite extends UpsertSuiteBase with LakeSQLCommandSoulTest {
       val e = intercept[AnalysisException] {
         sql(s"MERGE INTO lakesoul.`${snapshotManagement.table_name}` AS t USING source_table AS s" +
           s" ON t.hash = s.hash" +
-          s" WHEN MATCHED THEN UPDATE SET *" +
+          s" WHEN MATCHED AND t.VALUE=5 THEN UPDATE SET *" +
           s" WHEN NOT MATCHED THEN INSERT *")
       }
-      e.getMessage() should (include("Convert merge into to upsert with merge condition") and include("is not supported"))
+      e.getMessage() should (include("Convert merge into to upsert with MatchedAction") and include("is not supported"))
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpsertSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpsertSuiteBase.scala
@@ -39,19 +39,19 @@ class UpsertSuiteBase extends QueryTest
 
   var snapshotManagement: SnapshotManagement = _
 
-  protected def tempPath = tempDir.getCanonicalPath
+  protected def tempPath: String = tempDir.getCanonicalPath
 
   protected def readLakeSoulTable(path: String): DataFrame = {
     spark.read.format("lakesoul").load(path)
   }
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     super.beforeEach()
     tempDir = Utils.createTempDir()
     snapshotManagement = SnapshotManagement(new Path(tempPath))
   }
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     try {
       Utils.deleteRecursively(tempDir)
       try {


### PR DESCRIPTION
1. Convert MergeInto to Upsert when the following conditions are matched:
	1. Merge condition are assignments on all primary key columns
	2. No additional conditions in Update/Insert Actions
	3. Update expressions are only assignments
1. Currently delete action is not supported. We plan to support delete after cdc feature become stable
2. Add MergeInto test cases

Some known problems:
1. Spark performs analysis for MergeIntoTable logical plan only when no ACCEPT_ANY_SCHEMA presented in table capability. We should only add ACCEPT_ANY_SCHEMA when LakeSoulSQLConf.SCHEMA_AUTO_MIGRATE is enabled. However this causes some behavior change, e.g. some column nullability compatibility checks during dataframe writes would fail:
	1. Using Seq to DF method would create nullable schema for StringType, however we require partitioning columns to be non-nullable. We should use SparkSession.createDataFrame with proper schema instead.
	1. SQL like "insert into table partition (part = 1)" would create a cast expression, which would also resolve to nullable, causing the same problem. Enable schema auto migration to work around this issue.