### PR TITLE
Optimize duplicate tests and code

### DIFF
--- a/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
+++ b/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
@@ -107,12 +107,15 @@ class LakeSoulSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectPostHocResolutionRule { session =>
       PreprocessTableDelete(session.sessionState.conf)
     }
+
     extensions.injectPostHocResolutionRule { session =>
       LakeSoulPostHocAnalysis(session)
     }
-    extensions.injectResolutionRule{ session =>
+
+    extensions.injectResolutionRule { session =>
       ProcessCDCTableMergeOnRead(session.sessionState.conf)
     }
+
     extensions.injectResolutionRule { session =>
       RewriteQueryByMaterialView(session)
     }

--- a/src/main/scala/org/apache/spark/sql/lakesoul/rules/ProcessCDCTableMergeOnRead.scala
+++ b/src/main/scala/org/apache/spark/sql/lakesoul/rules/ProcessCDCTableMergeOnRead.scala
@@ -1,39 +1,46 @@
+/*
+ * Copyright [2022] [DMetaSoul Team]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.lakesoul.rules
+
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.lakesoul.{LakeSoulTableProperties, LakeSoulTableRelationV2}
+import org.apache.spark.sql.lakesoul.LakeSoulTableProperties
 import org.apache.spark.sql.lakesoul.catalog.LakeSoulTableV2
-import org.apache.spark.sql.lakesoul.exception.LakeSoulErrors
-case class ProcessCDCTableMergeOnRead (sqlConf: SQLConf) extends Rule[LogicalPlan]{
-  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsDown   {
-    case p: LogicalPlan if p.children.exists(_.isInstanceOf[DataSourceV2Relation]) && !p.isInstanceOf[Filter] =>
-      p.children.toSeq.find(_.isInstanceOf[DataSourceV2Relation]).get match  {
-      case dsv2@DataSourceV2Relation(table: LakeSoulTableV2, _, _, _, _)=>{
-        val value=getLakeSoulTableCDCColumn(table)
-        if(value.nonEmpty){
-          p.withNewChildren(Filter(Column(expr(s" ${value.get}!= 'delete'").expr).expr,dsv2)::Nil)
-        }
-        else {
-          p
-        }
-      }
 
-    }
-   }
-  private def lakeSoulTableHasHashPartition(table: LakeSoulTableV2): Boolean = {
-    table.snapshotManagement.snapshot.getTableInfo.hash_column.nonEmpty
+case class ProcessCDCTableMergeOnRead(sqlConf: SQLConf) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsDown {
+    case p: LogicalPlan if p.children.exists(_.isInstanceOf[DataSourceV2Relation]) && !p.isInstanceOf[Filter] =>
+      p.children.find(_.isInstanceOf[DataSourceV2Relation]).get match {
+        case dsv2@DataSourceV2Relation(table: LakeSoulTableV2, _, _, _, _) =>
+          val value = getLakeSoulTableCDCColumn(table)
+          if (value.nonEmpty) {
+            p.withNewChildren(Filter(Column(expr(s" ${value.get}!= 'delete'").expr).expr, dsv2) :: Nil)
+          }
+          else {
+            p
+          }
+      }
   }
-  private def lakeSoulTableCDCColumn(table: LakeSoulTableV2): Boolean = {
-    table.snapshotManagement.snapshot.getTableInfo.configuration.contains(LakeSoulTableProperties.lakeSoulCDCChangePropKey)
-  }
+
   private def getLakeSoulTableCDCColumn(table: LakeSoulTableV2): Option[String] = {
     table.snapshotManagement.snapshot.getTableInfo.configuration.get(LakeSoulTableProperties.lakeSoulCDCChangePropKey)
   }
-
 }

--- a/src/test/scala/com/dmetasoul/lakesoul/tables/LakeSoulTableSuite.scala
+++ b/src/test/scala/com/dmetasoul/lakesoul/tables/LakeSoulTableSuite.scala
@@ -19,13 +19,13 @@ package com.dmetasoul.lakesoul.tables
 import java.util.Locale
 
 import org.apache.spark.sql.lakesoul.LakeSoulUtils
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 
 class LakeSoulTableSuite extends QueryTest
   with SharedSparkSession
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
 
   test("forPath") {
     withTempDir { dir =>

--- a/src/test/scala/org/apache/spark/sql/execution/datasource/ParquetScanSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasource/ParquetScanSuite.scala
@@ -20,13 +20,13 @@ import com.dmetasoul.lakesoul.tables.LakeSoulTable
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions.{col, last}
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, TestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, TestUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.scalatest.BeforeAndAfterEach
 
 class ParquetScanSuite extends QueryTest
   with SharedSparkSession with BeforeAndAfterEach
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/DDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/DDLSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.schema.InvariantViolationException
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructType}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -28,7 +28,7 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import scala.collection.JavaConverters._
 
 class DDLSuite extends DDLTestBase with SharedSparkSession
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
 
   override protected def verifyDescribeTable(tblName: String): Unit = {
     val res = sql(s"DESCRIBE TABLE $tblName").collect()

--- a/src/test/scala/org/apache/spark/sql/lakesoul/DDLUsingPathSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/DDLUsingPathSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.lakesoul
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.scalatest.Tag
@@ -130,6 +130,6 @@ trait DDLUsingPathTests extends QueryTest
 
 }
 
-class DDLUsingPathSuite extends DDLUsingPathTests with LakeSQLCommandSoulTest {
+class DDLUsingPathSuite extends DDLUsingPathTests with LakeSoulSQLCommandTest {
 }
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/DataFrameWriterV2Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/DataFrameWriterV2Suite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table,
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.lakesoul.catalog.{LakeSoulCatalog, LakeSoulTableV2}
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -411,7 +411,7 @@ trait DataFrameWriterV2Tests
 
 class DataFrameWriterV2Suite
   extends DataFrameWriterV2Tests
-    with LakeSQLCommandSoulTest {
+    with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/InsertIntoTableSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/InsertIntoTableSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{PARTITION_OVERWRITE_MODE, PartitionOverwriteMode}
 import org.apache.spark.sql.lakesoul.schema.SchemaUtils
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, LakeSoulTestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, LakeSoulTestUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.scalatest.BeforeAndAfter
@@ -36,7 +36,7 @@ import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
 
 class InsertIntoSQLSuite extends InsertIntoTests(false, true)
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
   override protected def doInsert(tableName: String, insert: DataFrame, mode: SaveMode): Unit = {
     val tmpView = "tmp_view"
     withTempView(tmpView) {
@@ -48,7 +48,7 @@ class InsertIntoSQLSuite extends InsertIntoTests(false, true)
 }
 
 class InsertIntoSQLByPathSuite extends InsertIntoTests(false, true)
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
   override protected def doInsert(tableName: String, insert: DataFrame, mode: SaveMode): Unit = {
     val tmpView = "tmp_view"
     withTempView(tmpView) {
@@ -85,7 +85,7 @@ class InsertIntoSQLByPathSuite extends InsertIntoTests(false, true)
 }
 
 class InsertIntoDataFrameSuite extends InsertIntoTests(false, false)
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
   override protected def doInsert(tableName: String, insert: DataFrame, mode: SaveMode): Unit = {
     val dfw = insert.write.format(v2Format)
     if (mode != null) {
@@ -96,7 +96,7 @@ class InsertIntoDataFrameSuite extends InsertIntoTests(false, false)
 }
 
 class InsertIntoDataFrameByPathSuite extends InsertIntoTests(false, false)
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
   override protected def doInsert(tableName: String, insert: DataFrame, mode: SaveMode): Unit = {
     val dfw = insert.write.format(v2Format)
     if (mode != null) {

--- a/src/test/scala/org/apache/spark/sql/lakesoul/NotSupportedDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/NotSupportedDDLSuite.scala
@@ -20,7 +20,7 @@ import com.dmetasoul.lakesoul.tables.LakeSoulTable
 
 import java.util.Locale
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
 class NotSupportedDDLSuite
   extends NotSupportedDDLBase
     with SharedSparkSession
-    with LakeSQLCommandSoulTest
+    with LakeSoulSQLCommandTest
 
 
 abstract class NotSupportedDDLBase extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/lakesoul/TableCreationTests.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/TableCreationTests.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, LakeSoulTestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, LakeSoulTestUtils}
 import org.apache.spark.sql.lakesoul.utils.DataFileInfo
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{MetadataBuilder, StructType}
@@ -1457,7 +1457,7 @@ trait TableCreationTests
 
 class TableCreationSuite
   extends TableCreationTests
-    with LakeSQLCommandSoulTest {
+    with LakeSoulSQLCommandTest {
 
   private def loadTable(tableName: String): Table = {
     val ti = spark.sessionState.sqlParser.parseMultipartIdentifier(tableName)

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/AlterTableTests.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/AlterTableTests.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.SnapshotManagement
 import org.apache.spark.sql.lakesoul.catalog.LakeSoulCatalog
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, LakeSoulTestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, LakeSoulTestUtils}
 import org.apache.spark.sql.lakesoul.utils.DataFileInfo
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -1300,9 +1300,9 @@ trait AlterTableByPathTests extends AlterTableLakeSoulTestBase {
 
 class AlterTableByNameSuite
   extends AlterTableByNameTests
-    with LakeSQLCommandSoulTest {
+    with LakeSoulSQLCommandTest {
 
 
 }
 
-class AlterTableByPathSuite extends AlterTableByPathTests with LakeSQLCommandSoulTest
+class AlterTableByPathSuite extends AlterTableByPathTests with LakeSoulSQLCommandTest

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteSQLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteSQLSuite.scala
@@ -16,9 +16,9 @@
 
 package org.apache.spark.sql.lakesoul.commands
 
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 
-class DeleteSQLSuite extends DeleteSuiteBase with LakeSQLCommandSoulTest {
+class DeleteSQLSuite extends DeleteSuiteBase with LakeSoulSQLCommandTest {
 
   override protected def executeDelete(target: String, where: String = null): Unit = {
     val whereClause = Option(where).map(c => s"WHERE $c").getOrElse("")

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteScalaSuite.scala
@@ -19,13 +19,12 @@ package org.apache.spark.sql.lakesoul.commands
 import com.dmetasoul.lakesoul
 import com.dmetasoul.lakesoul.tables.{LakeSoulTable, LakeSoulTableTestUtils}
 import org.apache.spark.sql.lakesoul.SnapshotManagement
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.{Row, functions}
 
-class DeleteScalaSuite extends DeleteSuiteBase with LakeSQLCommandSoulTest {
+class DeleteScalaSuite extends DeleteSuiteBase with LakeSoulSQLCommandTest {
 
   import testImplicits._
-
 
   test("delete cached table by path") {
     Seq((2, 2), (1, 4)).toDF("key", "value")
@@ -64,7 +63,7 @@ class DeleteScalaSuite extends DeleteSuiteBase with LakeSQLCommandSoulTest {
         case tableName :: Nil => tableName -> None // just table name
         case tableName :: alias :: Nil => // tablename SPACE alias OR tab SPACE lename
           val ordinary = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toSet
-          if (!alias.forall(ordinary.contains(_))) {
+          if (!alias.forall(ordinary.contains)) {
             (tableName + " " + alias) -> None
           } else {
             tableName -> Some(alias)
@@ -84,7 +83,7 @@ class DeleteScalaSuite extends DeleteSuiteBase with LakeSQLCommandSoulTest {
         LakeSoulTableTestUtils.createTable(spark.table(tableNameOrPath),
           SnapshotManagement(tableNameOrPath))
       }
-      optionalAlias.map(table.as(_)).getOrElse(table)
+      optionalAlias.map(table.as).getOrElse(table)
     }
 
     if (where != null) {

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/DeleteSuiteBase.scala
@@ -17,49 +17,15 @@
 package org.apache.spark.sql.lakesoul.commands
 
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
-
-import java.io.File
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.lakesoul.SnapshotManagement
+import org.apache.spark.sql.lakesoul.test.LakeSoulTestBeforeAndAfterEach
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.util.Utils
-import org.scalatest.BeforeAndAfterEach
 
 abstract class DeleteSuiteBase extends QueryTest
-  with SharedSparkSession with BeforeAndAfterEach {
+  with SharedSparkSession with LakeSoulTestBeforeAndAfterEach {
 
   import testImplicits._
-
-  var tempDir: File = _
-
-  var snapshotManagement: SnapshotManagement = _
-
-  protected def tempPath: String = tempDir.getCanonicalPath
-
-  protected def readLakeSoulTable(path: String): DataFrame = {
-    spark.read.format("lakesoul").load(path)
-  }
-
-  override def beforeEach() {
-    super.beforeEach()
-    tempDir = Utils.createTempDir()
-    snapshotManagement = SnapshotManagement(tempPath)
-  }
-
-  override def afterEach() {
-    try {
-      Utils.deleteRecursively(tempDir)
-      try {
-        snapshotManagement.updateSnapshot()
-        LakeSoulTable.forPath(snapshotManagement.table_name).dropTable()
-      } catch {
-        case e: Exception =>
-      }
-    } finally {
-      super.afterEach()
-    }
-  }
 
   protected def executeDelete(target: String, where: String = null): Unit
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/MaterialViewSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/MaterialViewSuite.scala
@@ -21,14 +21,14 @@ import com.dmetasoul.lakesoul.tables.LakeSoulTable
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.lakesoul.SnapshotManagement
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.util.Utils
 import org.scalatest.BeforeAndAfter
 
 class MaterialViewSuite extends QueryTest
-  with SharedSparkSession with LakeSQLCommandSoulTest with BeforeAndAfter {
+  with SharedSparkSession with LakeSoulSQLCommandTest with BeforeAndAfter {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateSQLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateSQLSuite.scala
@@ -17,9 +17,9 @@
 package org.apache.spark.sql.lakesoul.commands
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 
-class UpdateSQLSuite extends UpdateSuiteBase with LakeSQLCommandSoulTest {
+class UpdateSQLSuite extends UpdateSuiteBase with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateScalaSuite.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.lakesoul.commands
 import com.dmetasoul.lakesoul
 import com.dmetasoul.lakesoul.tables.{LakeSoulTable, LakeSoulTableTestUtils}
 import org.apache.spark.sql.lakesoul.SnapshotManagement
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.{Row, functions}
 
 import java.util.Locale
 
-class UpdateScalaSuite extends UpdateSuiteBase with LakeSQLCommandSoulTest {
+class UpdateScalaSuite extends UpdateSuiteBase with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpdateSuiteBase.scala
@@ -17,59 +17,24 @@
 package org.apache.spark.sql.lakesoul.commands
 
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
-
-import java.io.File
-import java.util.Locale
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.lakesoul.SnapshotManagement
-import org.apache.spark.sql.lakesoul.test.LakeSoulTestUtils
+import org.apache.spark.sql.lakesoul.test.{LakeSoulTestBeforeAndAfterEach, LakeSoulTestUtils}
 import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.util.Utils
-import org.scalatest.BeforeAndAfterEach
 
+import java.util.Locale
 import scala.language.implicitConversions
 
 abstract class UpdateSuiteBase
   extends QueryTest
     with SharedSparkSession
-    with BeforeAndAfterEach
+    with LakeSoulTestBeforeAndAfterEach
     with SQLTestUtils
     with LakeSoulTestUtils {
 
   import testImplicits._
-
-  var tempDir: File = _
-
-  var snapshotManagement: SnapshotManagement = _
-
-  protected def tempPath = tempDir.getCanonicalPath
-
-  protected def readLakeSoulTable(path: String): DataFrame = {
-    spark.read.format("lakesoul").load(path)
-  }
-
-  override def beforeEach() {
-    super.beforeEach()
-    tempDir = Utils.createTempDir()
-    snapshotManagement = SnapshotManagement(new Path(tempPath))
-  }
-
-  override def afterEach() {
-    try {
-      Utils.deleteRecursively(tempDir)
-      try {
-        LakeSoulTable.forPath(snapshotManagement.table_name).dropTable()
-      } catch {
-        case e: Exception =>
-      }
-    } finally {
-      super.afterEach()
-    }
-  }
 
   protected def executeUpdate(lakeSoulTable: String, set: Seq[String], where: String): Unit = {
     executeUpdate(lakeSoulTable, set.mkString(", "), where)

--- a/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpsertSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/commands/UpsertSuiteBase.scala
@@ -17,53 +17,17 @@
 package org.apache.spark.sql.lakesoul.commands
 
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
-
-import java.io.File
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.lakesoul.SnapshotManagement
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
-import org.apache.spark.sql.lakesoul.test.LakeSoulTestUtils
+import org.apache.spark.sql.lakesoul.test.{LakeSoulTestBeforeAndAfterEach, LakeSoulTestUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.util.Utils
-import org.scalatest.BeforeAndAfterEach
 
 class UpsertSuiteBase extends QueryTest
-  with SharedSparkSession with BeforeAndAfterEach
+  with SharedSparkSession with LakeSoulTestBeforeAndAfterEach
   with LakeSoulTestUtils {
 
   import testImplicits._
-
-  var tempDir: File = _
-
-  var snapshotManagement: SnapshotManagement = _
-
-  protected def tempPath: String = tempDir.getCanonicalPath
-
-  protected def readLakeSoulTable(path: String): DataFrame = {
-    spark.read.format("lakesoul").load(path)
-  }
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    tempDir = Utils.createTempDir()
-    snapshotManagement = SnapshotManagement(new Path(tempPath))
-  }
-
-  override def afterEach(): Unit = {
-    try {
-      Utils.deleteRecursively(tempDir)
-      try {
-        snapshotManagement.updateSnapshot()
-        LakeSoulTable.forPath(snapshotManagement.table_name).dropTable()
-      } catch {
-        case e: Exception =>
-      }
-    } finally {
-      super.afterEach()
-    }
-  }
 
   //  protected def executeUpsert(df: DataFrame, condition: Option[String], tableName: String): Unit
   protected def executeUpsert(df: DataFrame, condition: Option[String], tableName: String): Unit = {

--- a/src/test/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulPostHocAnalysisSuiteSoul.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/rules/LakeSoulPostHocAnalysisSuiteSoul.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.lakesoul.rules
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, TestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, TestUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class LakeSoulPostHocAnalysisSuiteSoul extends QueryTest with SharedSparkSession with LakeSQLCommandSoulTest {
+class LakeSoulPostHocAnalysisSuiteSoul extends QueryTest with SharedSparkSession with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/rules/RewriteQueryByMaterialViewBase.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/rules/RewriteQueryByMaterialViewBase.scala
@@ -17,14 +17,14 @@
 package org.apache.spark.sql.lakesoul.rules
 
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.util.Utils
 import org.scalatest.BeforeAndAfterAll
 
 abstract class RewriteQueryByMaterialViewBase extends QueryTest
-  with SharedSparkSession with LakeSQLCommandSoulTest with BeforeAndAfterAll {
+  with SharedSparkSession with LakeSoulSQLCommandTest with BeforeAndAfterAll {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/schema/CaseSensitivitySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/schema/CaseSensitivitySuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.SnapshotManagement
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.lakesoul.utils.DataFileInfo
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException}
 import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{AnalysisException, Dataset, QueryTest, Row}
 
 class CaseSensitivitySuite extends QueryTest
-  with SharedSparkSession with SQLTestUtils with LakeSQLCommandSoulTest {
+  with SharedSparkSession with SQLTestUtils with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/schema/SchemaEnforcementSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/schema/SchemaEnforcementSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
-import org.apache.spark.sql.lakesoul.test.{LakeSQLCommandSoulTest, LakeSoulTestUtils}
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, LakeSoulTestUtils}
 import org.apache.spark.sql.lakesoul.{SnapshotManagement, LakeSoulOptions}
 import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.test.SharedSparkSession
@@ -300,7 +300,7 @@ trait AppendSaveModeTests extends BatchWriterSoulTest {
 }
 
 trait AppendOutputModeTests extends SchemaEnforcementSuiteBase with SharedSparkSession
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
 
   import testImplicits._
 
@@ -730,7 +730,7 @@ trait OverwriteSaveModeTests extends BatchWriterSoulTest {
 }
 
 trait CompleteOutputModeTests extends SchemaEnforcementSuiteBase with SharedSparkSession
-  with LakeSQLCommandSoulTest {
+  with LakeSoulSQLCommandTest {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/lakesoul/schema/SchemaValidationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/schema/SchemaValidationSuite.scala
@@ -21,7 +21,7 @@ import com.dmetasoul.lakesoul.tables.LakeSoulTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.lakesoul.test.LakeSQLCommandSoulTest
+import org.apache.spark.sql.lakesoul.test.LakeSoulSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SparkSession}
 
@@ -33,7 +33,7 @@ import java.util.concurrent.CountDownLatch
   * command completes analysis but before the command starts the transaction. We want to make sure
   * That we do not corrupt tables.
   */
-class SchemaValidationSuite extends QueryTest with SharedSparkSession with LakeSQLCommandSoulTest {
+class SchemaValidationSuite extends QueryTest with SharedSparkSession with LakeSoulSQLCommandTest {
 
   class BlockingRule(
                       blockActionLatch: CountDownLatch,

--- a/src/test/scala/org/apache/spark/sql/lakesoul/test/LakeSoulSQLCommandTest.scala
+++ b/src/test/scala/org/apache/spark/sql/lakesoul/test/LakeSoulSQLCommandTest.scala
@@ -104,7 +104,7 @@ class LakeSoulTestSparkSession(sparkConf: SparkConf) extends TestSparkSession(sp
   * A trait for tests that are testing a fully set up SparkSession with all of LakeSoul's requirements,
   * such as the configuration of the LakeSoulCatalog and the addition of all LakeSoul extensions.
   */
-trait LakeSQLCommandSoulTest extends LakeSoulTestUtils {
+trait LakeSoulSQLCommandTest extends LakeSoulTestUtils {
   self: SharedSparkSession =>
 
   override protected def createSparkSession: TestSparkSession = {


### PR DESCRIPTION
1. Abstract some duplicate beforeEach/afterEach code
2. Avoid some duplicate cases executed.

Fix #1 