### PR TITLE
[Flink] write timestamp to int64 instead of int96 in flink sink

### DIFF
--- a/lakesoul-flink/pom.xml
+++ b/lakesoul-flink/pom.xml
@@ -84,19 +84,19 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop-bundle</artifactId>
-            <version>1.11.1</version>
+            <version>1.12.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-sql-connector-mysql-cdc</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-sql-connector-oracle-cdc</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
         </dependency>
 
         <dependency>
@@ -260,6 +260,15 @@
                             <exclude>org/apache/log4j/**</exclude>
                         </excludes>
                     </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>org.apache.flink:flink-parquet_2.12</artifact>
+                            <excludes>
+                                <exclude>org/apache/flink/formats/parquet/utils/ParquetSchemaConverter*</exclude>
+                                <exclude>org/apache/flink/formats/parquet/row/ParquetRowDataWriter*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <relocations>
                         <relocation>
                             <pattern>com.zaxxer.hikari</pattern>

--- a/lakesoul-flink/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriter.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This code is copied from apache/flink, and modify the behavior of
+ * writing timestamp field to int64 instead of int96.
+ */
+
+package org.apache.flink.formats.parquet.row;
+
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.Type;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+import static org.apache.flink.formats.parquet.utils.ParquetSchemaConverter.computeMinBytesForDecimalPrecision;
+import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.JULIAN_EPOCH_OFFSET_DAYS;
+import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.MILLIS_IN_DAY;
+import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.NANOS_PER_MILLISECOND;
+import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.NANOS_PER_SECOND;
+
+/** Writes a record to the Parquet API with the expected schema in order to be written to a file. */
+public class ParquetRowDataWriter {
+
+    private final RecordConsumer recordConsumer;
+    private final boolean utcTimestamp;
+
+    private final FieldWriter[] filedWriters;
+    private final String[] fieldNames;
+
+    public ParquetRowDataWriter(
+            RecordConsumer recordConsumer,
+            RowType rowType,
+            GroupType schema,
+            boolean utcTimestamp) {
+        this.recordConsumer = recordConsumer;
+        this.utcTimestamp = utcTimestamp;
+
+        this.filedWriters = new FieldWriter[rowType.getFieldCount()];
+        this.fieldNames = rowType.getFieldNames().toArray(new String[0]);
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            this.filedWriters[i] = createWriter(rowType.getTypeAt(i), schema.getType(i));
+        }
+    }
+
+    /**
+     * It writes a record to Parquet.
+     *
+     * @param record Contains the record that is going to be written.
+     */
+    public void write(final RowData record) {
+        recordConsumer.startMessage();
+        for (int i = 0; i < filedWriters.length; i++) {
+            if (!record.isNullAt(i)) {
+                String fieldName = fieldNames[i];
+                FieldWriter writer = filedWriters[i];
+
+                recordConsumer.startField(fieldName, i);
+                writer.write(record, i);
+                recordConsumer.endField(fieldName, i);
+            }
+        }
+        recordConsumer.endMessage();
+    }
+
+    private FieldWriter createWriter(LogicalType t, Type type) {
+        if (type.isPrimitive()) {
+            switch (t.getTypeRoot()) {
+                case CHAR:
+                case VARCHAR:
+                    return new StringWriter();
+                case BOOLEAN:
+                    return new BooleanWriter();
+                case BINARY:
+                case VARBINARY:
+                    return new BinaryWriter();
+                case DECIMAL:
+                    DecimalType decimalType = (DecimalType) t;
+                    return createDecimalWriter(decimalType.getPrecision(), decimalType.getScale());
+                case TINYINT:
+                    return new ByteWriter();
+                case SMALLINT:
+                    return new ShortWriter();
+                case DATE:
+                case TIME_WITHOUT_TIME_ZONE:
+                case INTEGER:
+                    return new IntWriter();
+                case BIGINT:
+                    return new LongWriter();
+                case FLOAT:
+                    return new FloatWriter();
+                case DOUBLE:
+                    return new DoubleWriter();
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                    TimestampType timestampType = (TimestampType) t;
+                    return new TimestampWriter(timestampType.getPrecision());
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    LocalZonedTimestampType localZonedTimestampType = (LocalZonedTimestampType) t;
+                    return new TimestampWriter(localZonedTimestampType.getPrecision());
+                default:
+                    throw new UnsupportedOperationException("Unsupported type: " + type);
+            }
+        } else {
+            throw new IllegalArgumentException("Unsupported  data type: " + t);
+        }
+    }
+
+    private interface FieldWriter {
+
+        void write(RowData row, int ordinal);
+    }
+
+    private class BooleanWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addBoolean(row.getBoolean(ordinal));
+        }
+    }
+
+    private class ByteWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addInteger(row.getByte(ordinal));
+        }
+    }
+
+    private class ShortWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addInteger(row.getShort(ordinal));
+        }
+    }
+
+    private class LongWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addLong(row.getLong(ordinal));
+        }
+    }
+
+    private class FloatWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addFloat(row.getFloat(ordinal));
+        }
+    }
+
+    private class DoubleWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addDouble(row.getDouble(ordinal));
+        }
+    }
+
+    private class StringWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addBinary(Binary.fromReusedByteArray(row.getString(ordinal).toBytes()));
+        }
+    }
+
+    private class BinaryWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addBinary(Binary.fromReusedByteArray(row.getBinary(ordinal)));
+        }
+    }
+
+    private class IntWriter implements FieldWriter {
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            recordConsumer.addInteger(row.getInt(ordinal));
+        }
+    }
+
+    /**
+     * LakeSoul hack this class to use int64 for timestamp
+     * because int96 in parquet lacks of min-max stats support
+     * which would harm performance in some queries
+     */
+    private class TimestampWriter implements FieldWriter {
+
+        private final int precision;
+
+        private TimestampWriter(int precision) {
+            this.precision = precision;
+        }
+
+        @Override
+        public void write(RowData row, int ordinal) {
+            TimestampData timestampData = row.getTimestamp(ordinal, precision);
+            Timestamp timestamp = timestampData.toTimestamp();
+            long mills = timestamp.getTime();
+            int microFraction = timestamp.getNanos() / 1000;
+            long time = mills * 1000 + microFraction;
+            recordConsumer.addLong(time);
+        }
+    }
+
+    private FieldWriter createDecimalWriter(int precision, int scale) {
+        Preconditions.checkArgument(
+                precision <= DecimalType.MAX_PRECISION,
+                "Decimal precision %s exceeds max precision %s",
+                precision,
+                DecimalType.MAX_PRECISION);
+
+        /*
+         * This is optimizer for UnscaledBytesWriter.
+         */
+        class LongUnscaledBytesWriter implements FieldWriter {
+            private final int numBytes;
+            private final int initShift;
+            private final byte[] decimalBuffer;
+
+            private LongUnscaledBytesWriter() {
+                this.numBytes = computeMinBytesForDecimalPrecision(precision);
+                this.initShift = 8 * (numBytes - 1);
+                this.decimalBuffer = new byte[numBytes];
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                long unscaledLong = row.getDecimal(ordinal, precision, scale).toUnscaledLong();
+                int i = 0;
+                int shift = initShift;
+                while (i < numBytes) {
+                    decimalBuffer[i] = (byte) (unscaledLong >> shift);
+                    i += 1;
+                    shift -= 8;
+                }
+
+                recordConsumer.addBinary(Binary.fromReusedByteArray(decimalBuffer, 0, numBytes));
+            }
+        }
+
+        class UnscaledBytesWriter implements FieldWriter {
+            private final int numBytes;
+            private final byte[] decimalBuffer;
+
+            private UnscaledBytesWriter() {
+                this.numBytes = computeMinBytesForDecimalPrecision(precision);
+                this.decimalBuffer = new byte[numBytes];
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                byte[] bytes = row.getDecimal(ordinal, precision, scale).toUnscaledBytes();
+                byte[] writtenBytes;
+                if (bytes.length == numBytes) {
+                    // Avoid copy.
+                    writtenBytes = bytes;
+                } else {
+                    byte signByte = bytes[0] < 0 ? (byte) -1 : (byte) 0;
+                    Arrays.fill(decimalBuffer, 0, numBytes - bytes.length, signByte);
+                    System.arraycopy(
+                            bytes, 0, decimalBuffer, numBytes - bytes.length, bytes.length);
+                    writtenBytes = decimalBuffer;
+                }
+                recordConsumer.addBinary(Binary.fromReusedByteArray(writtenBytes, 0, numBytes));
+            }
+        }
+
+        // 1 <= precision <= 18, writes as FIXED_LEN_BYTE_ARRAY
+        // optimizer for UnscaledBytesWriter
+        if (DecimalDataUtils.is32BitDecimal(precision)
+                || DecimalDataUtils.is64BitDecimal(precision)) {
+            return new LongUnscaledBytesWriter();
+        }
+
+        // 19 <= precision <= 38, writes as FIXED_LEN_BYTE_ARRAY
+        return new UnscaledBytesWriter();
+    }
+}

--- a/lakesoul-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This code is copied from apache/flink, and modify the behavior of
+ * writing timestamp field to int64 instead of int96.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+/** Schema converter converts Parquet schema to and from Flink internal types. */
+public class ParquetSchemaConverter {
+
+    public static MessageType convertToParquetMessageType(String name, RowType rowType) {
+        Type[] types = new Type[rowType.getFieldCount()];
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            types[i] = convertToParquetType(rowType.getFieldNames().get(i), rowType.getTypeAt(i));
+        }
+        return new MessageType(name, types);
+    }
+
+    private static Type convertToParquetType(String name, LogicalType type) {
+        return convertToParquetType(name, type, Type.Repetition.OPTIONAL);
+    }
+
+    private static Type convertToParquetType(
+            String name, LogicalType type, Type.Repetition repetition) {
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
+                        .as(OriginalType.UTF8)
+                        .named(name);
+            case BOOLEAN:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition)
+                        .named(name);
+            case BINARY:
+            case VARBINARY:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
+                        .named(name);
+            case DECIMAL:
+                int precision = ((DecimalType) type).getPrecision();
+                int scale = ((DecimalType) type).getScale();
+                int numBytes = computeMinBytesForDecimalPrecision(precision);
+                return Types.primitive(
+                                PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+                        .precision(precision)
+                        .scale(scale)
+                        .length(numBytes)
+                        .as(OriginalType.DECIMAL)
+                        .named(name);
+            case TINYINT:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                        .as(OriginalType.INT_8)
+                        .named(name);
+            case SMALLINT:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                        .as(OriginalType.INT_16)
+                        .named(name);
+            case INTEGER:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                        .named(name);
+            case BIGINT:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+                        .named(name);
+            case FLOAT:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.FLOAT, repetition)
+                        .named(name);
+            case DOUBLE:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition)
+                        .named(name);
+            case DATE:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                        .as(OriginalType.DATE)
+                        .named(name);
+            case TIME_WITHOUT_TIME_ZONE:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                        .as(OriginalType.TIME_MILLIS)
+                        .named(name);
+            // LakeSoul use int64 physical type and TIMESTAMP_MICROS logical type for timestamp.
+            // Because int96 column in parquet does not have min-max stats
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+                        .as(OriginalType.TIMESTAMP_MICROS)
+                        .named(name);
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    public static int computeMinBytesForDecimalPrecision(int precision) {
+        int numBytes = 1;
+        while (Math.pow(2.0, 8 * numBytes - 1) < Math.pow(10.0, precision)) {
+            numBytes += 1;
+        }
+        return numBytes;
+    }
+}

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/TableSchemaWriterCreator.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/TableSchemaWriterCreator.java
@@ -113,6 +113,8 @@ public class TableSchemaWriterCreator implements Serializable {
 
     public static org.apache.hadoop.conf.Configuration getParquetConfiguration(ReadableConfig options) {
         org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+        conf.set("parquet.compression", "snappy");
+        conf.setInt("parquet.block.size", 32 * 1024 * 1024);
         Properties properties = new Properties();
         ((org.apache.flink.configuration.Configuration) options).addAllToProperties(properties);
         properties.forEach((k, v) -> conf.set(IDENTIFIER + "." + k, v.toString()));


### PR DESCRIPTION
Close #105 

Currently we hack flink-parquet files to use int64 for timestamp type. In the future we may move these logics to native io layer.